### PR TITLE
feat: AWS Secrets Manager module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-secretsmanager"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b60a73c8e0afa05093c01bd979b48727ca59dc154173ea2c46af26d05a2f39a"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http",
+ "tokio-stream",
+ "tower",
+]
+
+[[package]]
 name = "aws-sdk-ssm"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,9 +1090,11 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-iam",
+ "aws-sdk-secretsmanager",
  "aws-sdk-ssm",
  "aws-sdk-sts",
  "aws-smithy-http",
+ "aws-smithy-types",
  "aws-types",
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,10 @@ users = "0.11"
 aws-sdk-sts = "0.21.0"
 aws-sdk-iam = "0.21.0"
 aws-sdk-ssm = "0.21.0"
+aws-sdk-secretsmanager = "0.21.0"
 aws-config = "0.51.0"
 aws-smithy-http = "0.51.0"
+aws-smithy-types = "0.51.0"
 aws-types = "0.51.0"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 tokio = { version = "1", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-#[macro_use]
-extern crate enum_dispatch;
-extern crate xdg;
-
 pub mod core;
 pub mod modules;
 
@@ -35,6 +31,7 @@ pub struct NovopsArgs {
 /**
  * Structure containing all Outputs after resolving
  */
+#[derive(Debug, Clone)]
 pub struct NovopsOutputs {
     pub context: NovopsContext,
     pub variables: HashMap<String, VariableOutput>,
@@ -377,7 +374,7 @@ fn export_file_outputs(files: &Vec<FileOutput>){
             .mode(0o600)
             .open(&f.dest)
             .unwrap();
-        fd.write_all(f.content.as_bytes()).unwrap();
+        fd.write_all(&f.content).unwrap();
     }
 }
 

--- a/src/modules/aws/config.rs
+++ b/src/modules/aws/config.rs
@@ -67,6 +67,13 @@ pub async fn get_ssm_client(novops_aws: &AwsClientConfig) -> Result<aws_sdk_ssm:
     return Ok(aws_sdk_ssm::Client::new(&conf));
 }
 
+pub async fn get_secretsmanager_client(novops_aws: &AwsClientConfig) -> Result<aws_sdk_secretsmanager::Client, Error>{
+    let conf = get_sdk_config(novops_aws).await?;
+
+    debug!("Creating AWS Secrets Manager client with config {:?}", conf);
+    return Ok(aws_sdk_secretsmanager::Client::new(&conf));
+}
+
 /**
  * Generic AWS Client config xrapped around builder pattern
  * for easy loading from Novops config and per-module override

--- a/src/modules/aws/mod.rs
+++ b/src/modules/aws/mod.rs
@@ -1,3 +1,4 @@
 pub mod assume_role;
 pub mod config;
 pub mod ssm;
+pub mod secretsmanager;

--- a/src/modules/aws/secretsmanager.rs
+++ b/src/modules/aws/secretsmanager.rs
@@ -1,0 +1,103 @@
+use anyhow::Context;
+use aws_sdk_secretsmanager::output::GetSecretValueOutput;
+use serde::Deserialize;
+use async_trait::async_trait;
+use schemars::JsonSchema;
+use std::default::Default;
+
+use crate::core::{ResolveTo, NovopsContext};
+use crate::modules::aws::config::{build_mutable_client_config_from_context, get_secretsmanager_client};
+
+#[derive(Debug, Deserialize, Clone, PartialEq, JsonSchema)]
+pub struct AwsSecretsManagerSecretInput {
+    
+    pub aws_secret: AwsSecretsManagerSecret
+}
+
+/**
+ * Structure to request a Secrets Manager secret
+ * 
+ * Secret Manager content is either String or Binary so this Input implements 
+ * ResolveTo<String> and ResolveTo<Vec<u8>> to represent both situations
+ * 
+ * Depending on usage, resolving behavior is:
+ * - String for VariableInput: String is used for export
+ * - Binary for VariableInput: **Vec<u8> is encoded in UTF-8 for export**
+ * - String for FileInput: String's underlying Vec<u8> is written to file
+ * - Binary for FileInput: Vec<u8> data is written to file as-is
+ * 
+ * See https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
+ */
+#[derive(Debug, Deserialize, Clone, PartialEq, JsonSchema, Default)]
+pub struct AwsSecretsManagerSecret {
+    
+    /**
+     * Secret ID
+     */
+    pub id: String,
+
+    /**
+     * The unique identifier of the version of the secret to retrieve. 
+     */
+    pub version_id: Option<String>,
+
+    /**
+     * The staging label of the version of the secret to retrieve.
+     */
+    pub version_stage: Option<String>,
+}
+
+#[async_trait]
+impl ResolveTo<Vec<u8>> for AwsSecretsManagerSecretInput {
+    async fn resolve(&self, ctx: &NovopsContext) -> Result<Vec<u8>, anyhow::Error> {
+
+        let output = retrieve_secret(ctx, self).await?;
+
+        if output.secret_string().is_some(){
+            return Ok(output.secret_string().unwrap().to_string().into_bytes());
+        }
+
+        if output.secret_binary().is_some(){
+            return Ok(output.secret_binary().unwrap().clone().into_inner());
+        }
+
+        return Err(anyhow::format_err!("Secret value was neither string nor binary, got response: {:?}", output));
+        
+    }
+}
+
+#[async_trait]
+impl ResolveTo<String> for AwsSecretsManagerSecretInput {
+    async fn resolve(&self, ctx: &NovopsContext) -> Result<String, anyhow::Error> {
+
+        let output = retrieve_secret(ctx, self).await?;
+
+        if output.secret_string().is_some(){
+            return Ok(output.secret_string().unwrap().to_string());
+        }
+
+        if output.secret_binary().is_some(){
+            let binary = output.secret_binary().unwrap().clone().into_inner();
+            let result = String::from_utf8(binary)
+                .with_context(|| format!("Couldn't convert bytes from Secrets Manager secret '{}' to UTF-8 String. \
+                Non-UTF-8 binary data can't be used as Variable input yet. Either use File input for binary data or make sure it's a valid UTF-8 string.", self.aws_secret.id))?;
+            return Ok(result);
+        }
+
+        return Err(anyhow::format_err!("Secret value was neither string nor binary, got response: {:?}", output));        
+        
+    }
+}
+
+async fn retrieve_secret(ctx: &NovopsContext, input: &AwsSecretsManagerSecretInput) -> Result<GetSecretValueOutput, anyhow::Error>{
+    let client_conf = build_mutable_client_config_from_context(ctx);
+    let ssm_client = get_secretsmanager_client(&client_conf).await?;
+
+    let output = ssm_client.get_secret_value()
+        .secret_id(input.aws_secret.id.clone())
+        .set_version_id(input.aws_secret.version_id.clone())
+        .set_version_stage(input.aws_secret.version_stage.clone())
+        .send().await?;
+
+    return Ok(output);
+}

--- a/src/modules/files.rs
+++ b/src/modules/files.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use anyhow;
 use schemars::JsonSchema;
 
-use crate::core::{ResolveTo, NovopsContext, StringResolvableInput};
+use crate::core::{ResolveTo, NovopsContext, BytesResolvableInput};
 use crate::modules::variables::{VariableOutput};
 
 /**
@@ -43,7 +43,7 @@ pub struct FileInput {
     
     pub variable: Option<String>,
     
-    pub content: StringResolvableInput
+    pub content: BytesResolvableInput
 }
 
 /**
@@ -53,7 +53,7 @@ pub struct FileInput {
 pub struct FileOutput {
     pub dest: PathBuf,
     pub variable: VariableOutput,
-    pub content: String // TODO buffer? content may be long
+    pub content: Vec<u8> // TODO buffer? content may be long
 }
 
 /**

--- a/tests/.novops.aws_secretsmanager.yml
+++ b/tests/.novops.aws_secretsmanager.yml
@@ -1,0 +1,33 @@
+# Novops config used to test AWS modules with LocalStack
+name: test-aws
+
+environments:
+  dev:
+    variables:
+    - name: SECRETSMANAGER_VAR_STRING
+      value:
+        aws_secret:
+          id: novops-test-secretsmanager-string
+    
+    - name: SECRETSMANAGER_VAR_BINARY
+      value:
+        aws_secret:
+          id: novops-test-secretsmanager-binary
+
+    files:
+    - name: SECRETSMANAGER_FILE_STRING
+      dest: /tmp/SECRETSMANAGER_FILE_STRING
+      content:
+        aws_secret:
+          id: novops-test-secretsmanager-string
+    
+    - name: SECRETSMANAGER_FILE_BINARY
+      dest: /tmp/SECRETSMANAGER_FILE_BINARY
+      content:
+        aws_secret:
+          id: novops-test-secretsmanager-binary
+config:
+  default:
+    environment: dev
+  aws:
+    endpoint: "http://localhost:4566/" # LocalStack 

--- a/tests/.novops.aws_secretsmanager_var_nonutf8.yml
+++ b/tests/.novops.aws_secretsmanager_var_nonutf8.yml
@@ -1,0 +1,15 @@
+# Novops config used to test AWS modules with LocalStack
+name: test-aws
+
+environments:
+  dev:
+    variables:
+    - name: SECRETSMANAGER_VAR_BINARY_NON_UTF8
+      value:
+        aws_secret:
+          id: novops-test-secretsmanager-binary-non-utf8
+config:
+  default:
+    environment: dev
+  aws:
+    endpoint: "http://localhost:4566/" # LocalStack 

--- a/tests/test_aws.rs
+++ b/tests/test_aws.rs
@@ -3,8 +3,9 @@ mod test_utils;
 
 #[cfg(test)]
 mod tests {
-    use novops::modules::aws::config::{get_iam_client, get_ssm_client, AwsClientConfig};
+    use novops::modules::aws::config::{get_iam_client, get_ssm_client, get_secretsmanager_client, AwsClientConfig};
     use aws_sdk_ssm::model::ParameterType;
+    use aws_smithy_types::Blob;
     use crate::test_utils::load_env_for;
 
     use log::{info, debug};
@@ -50,6 +51,48 @@ mod tests {
 
         Ok(())
 
+    }
+
+    #[tokio::test]
+    async fn test_secretsmanager() -> Result<(), anyhow::Error> {
+
+        // Prepare env and dummy secret
+        setup_test_env().await?;
+
+        let expect_string = "Some-String-data?1548a~#{[[".to_string();
+        let expect_binary = vec![240, 159, 146, 150]; // 💖
+        ensure_test_secret_exists("novops-test-secretsmanager-string", Some(expect_string.clone()), None).await?;
+        ensure_test_secret_exists("novops-test-secretsmanager-binary", None, Some(expect_binary.clone())).await?;
+        
+        let outputs = load_env_for("aws_secretsmanager", "dev").await?;
+
+        info!("test_secretsmanager: Found variables: {:?}", outputs.variables);
+        info!("test_secretsmanager: Found files: {:?}", outputs.files);
+
+        assert_eq!(outputs.variables.get("SECRETSMANAGER_VAR_STRING").unwrap().value, expect_string);
+        assert_eq!(outputs.variables.get("SECRETSMANAGER_VAR_BINARY").unwrap().value.as_bytes(), expect_binary);
+        assert_eq!(outputs.files.get("/tmp/SECRETSMANAGER_FILE_STRING").unwrap().content, expect_string.as_bytes());
+        assert_eq!(outputs.files.get("/tmp/SECRETSMANAGER_FILE_BINARY").unwrap().content, expect_binary);
+
+        Ok(())
+    }
+
+    /**
+     * Variable input cannot be used for NON-UTF8 data yet. Let's test for proper error message. 
+     */
+    #[tokio::test]
+    async fn test_secretsmanager_non_utf8_variable() -> Result<(), anyhow::Error> {
+
+        // Prepare env and dummy secret
+        setup_test_env().await?;
+
+        let non_utf8_binary = vec![0, 159, 146, 150];
+        ensure_test_secret_exists("novops-test-secretsmanager-binary-non-utf8", None, Some(non_utf8_binary.clone())).await?;
+        
+        let outputs = load_env_for("aws_secretsmanager_var_nonutf8", "dev").await;
+        outputs.expect_err("Expected non UTF-8 binary data to provoke an error.");
+
+        Ok(())
     }
 
     /**
@@ -98,6 +141,33 @@ mod tests {
             .send().await?;
 
         info!("SSM param PUT {} response: {:?}", pname, r);
+
+        Ok(())
+    }
+
+    async fn ensure_test_secret_exists(sname: &str, string_value: Option<String>, binary_value: Option<Vec<u8>>) 
+            -> Result<(), anyhow::Error> {
+        let client = get_secretsmanager_client(&aws_test_config()).await?;
+
+        match client.describe_secret().secret_id(sname).send().await {
+            Ok(r) => {
+                info!("Secret {} already exists, deleting...", sname);
+
+                client.delete_secret()
+                    .secret_id(r.arn().unwrap())
+                    .force_delete_without_recovery(true)
+                    .send().await?;
+            },
+            Err(_) => {}, // secret does not exists, ignore
+        }
+
+        let r = client.create_secret()
+            .name(sname)
+            .set_secret_string(string_value)
+            .set_secret_binary(binary_value.map(|b| Blob::new(b)))
+            .send().await?;
+
+        info!("Create AWS secret {} response: {:?}", sname, r);
 
         Ok(())
     }


### PR DESCRIPTION
had to refactor a bit to allow FileInput to accept byte arrays instead of string as as sometime a secret manager may provide binary data which are not string