### PR TITLE
fix: fully static build with Docker BuildKit

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,16 +22,17 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+      
+      # Deploy services used for test (Hashicorp Vault, etc.)
       - uses: isbang/compose-action@v1.4.1
         with:
           compose-file: "./tests/docker-compose.yml"
           down-flags: "--volumes"
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      
+      - run: cargo test
 
   docker_build:
     name: Docker build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_and_test:
-    name: Rust build
+  cargo_test:
+    name: Cargo tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -32,3 +32,26 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+
+  docker_build:
+    name: Docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+    
+      - name: Build
+        uses: docker/build-push-action@v4
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: "type=local,dest=novops-build"
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: novops
+          path: |
+            novops-build/novops

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,23 +1,37 @@
 name: Publish Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*.*.*"
 
 jobs:
-  publish:
-    name: Publish ${{ matrix.target }}
+  build_publish:
+    name: Publish
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [x86_64-unknown-linux-musl]
     steps:
       - uses: actions/checkout@v3
-      - name: Compile and publish
-        uses: rust-build/rust-build.action@v1.4.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build
+        uses: docker/build-push-action@v4
         with:
-          RUSTTARGET: ${{ matrix.target }}
-          ARCHIVE_NAME: ${{ matrix.target }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: "type=local,dest=novops-build"
+
+      - uses: montudor/action-zip@v1
+        with:
+          args: zip -j novops-${{ runner.arch }}-${{ runner.os }}.zip novops-build/novops
+
+      - run: sha256sum novops-${{ runner.arch }}-${{ runner.os }}.zip > novops-${{ runner.arch }}-${{ runner.os }}.zip.sha256sum
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            novops-${{ runner.arch }}-${{ runner.os }}.zip
+            novops-${{ runner.arch }}-${{ runner.os }}.zip.sha256sum
+          body: See [CHANGELOG](https://github.com/novadiscovery/novops/blob/main/CHANGELOG.md)

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -2,6 +2,7 @@ name: Tag release
 
 on: workflow_dispatch
 
+# Create a tag on-demand with changelog
 jobs:
   changelog:
     name: Push changelog

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target/
 .novops
+build/
 
 # Tests output
 tests/output/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,19 @@
-# syntax=docker/dockerfile:experimental
-FROM rust:1.64.0-alpine3.16 as builder
+# Static build using musl
+# clux/muslrust provides static build of popular libraries
+# allowing a fully static binary as output
+FROM clux/muslrust:1.68.0-stable as builder
 
-RUN apk update && apk add --no-cache musl-dev
-
-WORKDIR /novops
+WORKDIR /build
 
 COPY Cargo.lock Cargo.lock
 COPY Cargo.toml Cargo.toml
 COPY src src/
 
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/novops/target \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,id=novops-reg-static \
+    --mount=type=cache,target=/build/target,id=novops-build-static \
     cargo build --release --target x86_64-unknown-linux-musl \
-    && cp /novops/target/x86_64-unknown-linux-musl/release/novops /novops-rust
+    && cp target/x86_64-unknown-linux-musl/release/novops /novops
 
-FROM alpine:3.16
+FROM scratch
 
-COPY --from=builder /novops-rust /usr/local/bin/novops
-
-CMD ["novops"]
+COPY --from=builder /novops /novops

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ docker:
 
 .PHONY: build
 build:
-	cargo build --release --target x86_64-unknown-linux-musl
+	docker buildx build . -o type=local,dest=build
 
 .PHONY: test-docker
 test-docker:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Novops setup secrets and configs in multi-environment context without having to 
 ## Install
 
 ```
-curl -L "https://github.com/novadiscovery/novops/releases/latest/download/x86_64-unknown-linux-musl.zip" -o novops.zip
+curl -L "https://github.com/novadiscovery/novops/releases/latest/download/novops-X64-Linux.zip" -o novops.zip
 unzip novops.zip
 sudo mv novops /usr/local/bin/novops
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Novops setup secrets and configs in multi-environment context without having to 
 - Integrate with various secret providers: Hashicorp Vault, AWS GCloud, Azure...
 - Easily integrated within most shells and CI systems: Gitlab, GitHub, Jenkins...
 - Manage multi-environment (dev, preprod, prod...)
-- Quick and easy installation using static binary
+- Quick and easy installation with fully static binary
 
 ### Modules: Hashicorp Vault, AWS, GCloud, Azure...
 
@@ -160,3 +160,7 @@ See [Usage and examples](./docs/usage.md#usage-and-examples)
 We welcome contributions: bug reports/fixes, modules, proposals... :)
 
 See [contribution guide](./CONTRIBUTING.md)
+
+
+https://users.rust-lang.org/t/building-executable-for-alpine-linux/13568/3
+https://github.com/clux/muslrust

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,16 +2,11 @@
 
 ## Build
 
-Plain binary:
+Novops is built with Docker BuildKit. Built binary is fully static. See [Dockerfile](../Dockerfile).
 
 ```sh
-carbo build 
-```
-
-Docker image (using BuildKit):
-
-```sh
-docker buildx build .
+# Result in ./build/novops
+make build
 ```
 
 ## Run test


### PR DESCRIPTION
build was not fully static but had some dynamically dependencies on glibc and openssl, causing segfault on non-Ubuntu systems

See https://github.com/novadiscovery/novops/issues/14