### PR TITLE
build: add healthcheck to test Vault server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 
 .PHONY: test-docker
 test-docker:
-	docker-compose -f tests/docker-compose.yml up -d
+	docker-compose -f tests/docker-compose.yml up -d --wait
 
 .PHONY: test
 test: test-docker

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,16 +3,24 @@ version: "3.8"
 services:
   vault:
     image: vault:1.12.2
+    container_name: vault
     cap_add:
     - IPC_LOCK
     ports:
     - 8200:8200
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: novops
+    healthcheck:
+      test: ["CMD", "wget", "localhost:8200/v1/sys/health", "-S", "-O", "-"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 3s
+
 
   # Adapted from https://github.com/localstack/localstack/blob/master/docker-compose.yml
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: localstack
     image: localstack/localstack:2.0.2
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway

--- a/tests/test_hvault.rs
+++ b/tests/test_hvault.rs
@@ -15,7 +15,7 @@ mod tests {
         }
     };
     use log::info;
-    use std::collections::HashMap;
+    use std::{ collections::HashMap, thread, time };
     use crate::test_utils::{load_env_for, test_setup, aws_ensure_role_exists, self};
     use novops::modules::hashivault::{
         client::{load_vault_token, load_vault_address},
@@ -32,6 +32,10 @@ mod tests {
         // enable kv2 engine
         let opts = HashMap::from([("version".to_string(), "2".to_string())]);
         enable_engine(&client, "kv2", "kv", Some(opts)).await?;
+
+        // sleep a few seconds as creating kv2 secret engine may take a few seconds
+        // vault may return a 400 in the meantime
+        thread::sleep(time::Duration::from_secs(3));
 
         kv2::set(
             &client,


### PR DESCRIPTION
avoid test flakiness as Vault sometime is not started before tests are run Localstack already has a healthcheck define