### PR TITLE
chore: fix release artifact upload

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -149,6 +149,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       
+      - uses: actions/checkout@v3
+
       - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-unstable


### PR DESCRIPTION
fix release again again again