### PR TITLE
fix: truncate file output before writing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -565,6 +565,7 @@ fn export_file_outputs(outputs: &NovopsOutputs) -> Result<(), anyhow::Error>{
         let mut fd = fs::OpenOptions::new()
             .create(true)
             .write(true)
+            .truncate(true)
             .mode(0o600)
             .open(&f.dest)
             .with_context(|| format!("Can't open {:?} for write with mode 0600", &f.dest))?;


### PR DESCRIPTION
after an initial load of file X, a sub-sequent load of the same file but with shorter content caused parts of the previous file to be kept

For example, a file loaded with content "abcdef", and loaded again with "123" would have content as "123def" as previous file content was not truncated.