### PR TITLE
chore: bump vaultrs to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3042,8 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "vaultrs"
-version = "0.7.0"
-source = "git+https://github.com/PierreBeucher/vaultrs?rev=aws-se-2023-05-15#809de3eee0880e6dfb5e7c64784eeb6308a3a11a"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb996bb053adadc767f8b0bda2a80bc2b67d24fe89f2b959ae919e200d79a19"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,7 @@ convert_case = "0.5.0"
 async-trait = "0.1.68"
 anyhow = { version = "1.0", features = ["backtrace"] }
 rand = "0.5"
-# Use our own version as AWS client is not yet merged in mainstream. See https://github.com/jmgilman/vaultrs/pull/58
-vaultrs = { git = "https://github.com/PierreBeucher/vaultrs", rev="aws-se-2023-05-15" }
+vaultrs = { version = "0.7.1" }
 url = "2.3.1"
 schemars = "0.8.10"
 http = "0.2"


### PR DESCRIPTION
Instead of using our own fork. Will allow merge of