### PR TITLE
Fix bitwarden example

### DIFF
--- a/docs/src/config/bitwarden.md
+++ b/docs/src/config/bitwarden.md
@@ -11,7 +11,7 @@ To use BitWarden module:
 environments:
   dev:
     files: 
-      - name: ssh-key
+      - variable: ssh-key
         content:
           bitwarden:
             # Name of the entry to load


### PR DESCRIPTION
`files:` does not support `- name`. Only `- symlink` or `- variable`